### PR TITLE
Ubuntu & Pop!_OS

### DIFF
--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -50,7 +50,9 @@
       ignore_errors: yes
 
 - name: Install Docker (Ubuntu)
-  hosts: distro_Ubuntu
+  hosts:
+    - distro_Ubuntu
+    - distro_Pop!_OS
   become: true
   tags:
     - dev
@@ -92,7 +94,9 @@
       ignore_errors: yes
 
 - name: Install Docker Compose (Ubuntu)
-  hosts: distro_Ubuntu
+  hosts:
+    - distro_Ubuntu
+    - distro_Pop!_OS
   vars:
     compose_version: 1.27.4
   tags:

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -56,7 +56,7 @@
     - dev
     - docker
   tasks:
-    - name: Install GPG key
+    - name: Add GPG key
       ansible.builtin.apt_key:
         keyserver: https://download.docker.com/linux/ubuntu/gpg
         id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -49,7 +49,7 @@
         append: yes
       ignore_errors: yes
 
-- name: Install Docker and Compose (Ubuntu)
+- name: Install Docker (Ubuntu)
   hosts: distro_Ubuntu
   become: true
   tags:

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -44,7 +44,7 @@
 
     - name: Add user to docker group
       ansible.builtin.user:
-        name: "{{ ansible_env.USERNAME }}"
+        name: "{{ ansible_env.USER }}"
         groups: docker
         append: yes
       ignore_errors: yes
@@ -86,7 +86,7 @@
 
     - name: Add user to docker group
       ansible.builtin.user:
-        name: "{{ ansible_env.USERNAME }}"
+        name: "{{ ansible_env.USER }}"
         groups: docker
         append: yes
       ignore_errors: yes

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -90,3 +90,28 @@
         groups: docker
         append: yes
       ignore_errors: yes
+
+- name: Install Docker Compose (Ubuntu)
+  hosts: distro_Ubuntu
+  vars:
+    compose_version: 1.27.4
+  tags:
+    - dev
+    - docker
+    - docker-compose
+  tasks:
+    - ansible.builtin.get_url:
+        url: https://github.com/docker/compose/releases/download/{{ compose_version }}/docker-compose-Linux-x86_64
+        dest: "{{ ansible_env.HOME }}/.local/bin/docker-compose"
+        mode: "0755"
+
+    - name: Create Bash completion directory
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.local/share/bash-completion/completions/"
+        state: directory
+        mode: "0755"
+
+    - name: Download Bash completion script
+      ansible.builtin.get_url:
+        url: https://raw.githubusercontent.com/docker/compose/{{ compose_version }}/contrib/completion/bash/docker-compose
+        dest: "{{ ansible_env.HOME }}/.local/share/bash-completion/completions/docker-compose"

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -67,7 +67,6 @@
         repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable
         filename: docker
         state: present
-        update_cache: yes
         validate_certs: yes
 
     - name: Install
@@ -76,6 +75,7 @@
           - containerd.io
           - docker-ce
           - docker-ce-cli
+        update_cache: yes
         state: latest
 
     - name: Enable docker service

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install Docker and Compose
+- name: Install Docker and Compose (Fedora)
   hosts: distro_Fedora
   become: true
   tags:
@@ -34,6 +34,48 @@
         name:
           - moby-engine
           - docker-compose
+        state: latest
+
+    - name: Enable docker service
+      ansible.builtin.systemd:
+        name: docker
+        enabled: yes
+        masked: no
+
+    - name: Add user to docker group
+      ansible.builtin.user:
+        name: "{{ ansible_env.USERNAME }}"
+        groups: docker
+        append: yes
+      ignore_errors: yes
+
+- name: Install Docker and Compose (Ubuntu)
+  hosts: distro_Ubuntu
+  become: true
+  tags:
+    - dev
+    - docker
+  tasks:
+    - name: Install GPG key
+      ansible.builtin.apt_key:
+        keyserver: https://download.docker.com/linux/ubuntu/gpg
+        id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+        state: present
+
+    - name: Add repository
+      ansible.builtin.apt_repository:
+        repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable
+        filename: docker
+        state: present
+        update_cache: yes
+        validate_certs: yes
+
+    - name: Install
+      ansible.builtin.apt:
+        name:
+          - containerd.io
+          - docker-ce
+          - docker-ce-cli
         state: latest
 
     - name: Enable docker service

--- a/ansible/homebrew.yml
+++ b/ansible/homebrew.yml
@@ -8,7 +8,7 @@
     - package-managers
     - sway
   tasks:
-    - name: Install dependencies (Fedora family)
+    - name: Install dependencies (Fedora)
       become: true
       ansible.builtin.dnf:
         name:
@@ -19,7 +19,7 @@
           - "@Development Tools"
       when: ansible_facts["distribution"] == "Fedora"
 
-    - name: Install dependencies (Ubuntu family)
+    - name: Install dependencies (Ubuntu)
       become: true
       ansible.builtin.apt:
         name:

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -52,7 +52,7 @@
     - name: Install general packages
       ansible.builtin.apt:
         name:
-          - apparmor
+          - apparmor-utils
           - apt-transport-https
           - ca-certificates
           - curl

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -79,6 +79,26 @@
         autoclean: yes
         autoremove: yes
 
+- name: Install extra system packages (Pop!_OS)
+  hosts: distro_Pop!_OS
+  become: true
+  tags:
+    - system-packages
+    - packages
+    - pop
+  tasks:
+    - ansible.builtin.apt:
+        name:
+          - atom
+          - chromium
+        update_cache: yes
+        state: latest
+
+    - name: Clean up
+      ansible.builtin.apt:
+        autoclean: yes
+        autoremove: yes
+
 - name: Install Miniconda
   hosts: localhost
   vars_files:

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -272,6 +272,13 @@
         argv:
           - /tmp/spacevim-install.sh
 
+    - name: Make vimproc
+      ansible.builtin.command:
+        argv:
+          - make
+          - -C
+          - "{{ ansible_env.HOME }}/.SpaceVim/bundle/vimproc.vim/"
+
     - name: Clean up
       ansible.builtin.file:
         path: /tmp/spacevim-install.sh

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -183,6 +183,7 @@
       when: ansible_facts["distribution"] == "Ubuntu"
 
     - name: Add Flathub repository
+      become: true
       community.general.flatpak_remote:
         name: flathub
         state: present

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -217,6 +217,7 @@
         remote: flathub
         method: system
         state: present
+      when: ansible_facts["distribution"] == "Fedora"
 
 - name: Setup Snap and install packages
   hosts: localhost

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -67,7 +67,7 @@
         state: absent
 
 - name: Install Fonts
-  hosts: distro_Fedora
+  hosts: localhost
   become: true
   tags:
     - fonts
@@ -76,12 +76,18 @@
     - ansible.builtin.dnf:
         name:
           - fira-code-fonts
-          - fontawesome-fonts
           - google-noto-sans-fonts
           - google-noto-serif-fonts
           - google-noto-emoji-fonts
           - google-noto-emoji-color-fonts
         state: latest
+      when: ansible_facts["distribution"] == "Fedora"
+    - ansible.builtin.apt:
+        name:
+          - fonts-firacode
+          - fonts-noto
+        state: latest
+      when: ansible_facts["distribution"] == "Ubuntu"
 
 - name: Install Google Cloud SDK
   hosts: localhost

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -1,11 +1,11 @@
 ---
-- name: Install general packages
+- name: Install general packages (Fedora)
   hosts: distro_Fedora
   become: true
   tags:
     - packages
   tasks:
-    - name: DNF update all
+    - name: Update all
       ansible.builtin.dnf:
         name: "*"
         state: latest
@@ -28,6 +28,48 @@
 
     - name: Clean up
       ansible.builtin.dnf:
+        autoremove: yes
+
+- name: Install general packages (Ubuntu)
+  hosts: distro_Ubuntu
+  become: true
+  tags:
+    - packages
+  tasks:
+    - name: Update all
+      ansible.builtin.apt:
+        name: "*"
+        state: latest
+
+    - name: Add fish shell repository
+      ansible.builtin.apt_repository:
+        repo: ppa:fish-shell/release-3
+        codename: focal
+        state: present
+        update_cache: yes
+        validate_certs: yes
+
+    - name: Install general packages
+      ansible.builtin.apt:
+        name:
+          - apparmor
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - fish
+          - git
+          - gnupg-agent
+          - htop
+          - make
+          - neovim
+          - software-properties-common
+          - vlc
+          - zsh
+        state: latest
+
+    - name: Clean up
+      ansible.builtin.apt:
+        autoclean: yes
         autoremove: yes
 
 - name: Install Miniconda

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -40,13 +40,13 @@
       ansible.builtin.apt:
         name: "*"
         state: latest
+        update_cache: yes
 
     - name: Add fish shell repository
       ansible.builtin.apt_repository:
         repo: ppa:fish-shell/release-3
         codename: focal
         state: present
-        update_cache: yes
         validate_certs: yes
 
     - name: Install general packages
@@ -65,6 +65,7 @@
           - software-properties-common
           - vlc
           - zsh
+        update_cache: yes
         state: latest
 
     - name: Clean up
@@ -256,6 +257,7 @@
     - dev
     - editors
     - packages
+    - vim
   tasks:
     - name: Download
       ansible.builtin.get_url:

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -33,7 +33,9 @@
         autoremove: yes
 
 - name: Install system packages (Ubuntu)
-  hosts: distro_Ubuntu
+  hosts:
+    - distro_Ubuntu
+    - distro_Pop!_OS
   become: true
   tags:
     - system-packages
@@ -134,7 +136,7 @@
           - fonts-firacode
           - fonts-noto
         state: latest
-      when: ansible_facts["distribution"] == "Ubuntu"
+      when: ansible_facts["distribution"] == "Ubuntu" or ansible_facts["distribution"] == "Pop!_OS"
 
 - name: Install Google Cloud SDK
   hosts: localhost
@@ -242,7 +244,7 @@
         name:
           - snapd
         state: latest
-      when: ansible_facts["distribution"] == "Ubuntu"
+      when: ansible_facts["distribution"] == "Ubuntu" or ansible_facts["distribution"] == "Pop!_OS"
 
     - name: Install packages
       community.general.snap:
@@ -325,7 +327,9 @@
         state: absent
 
 - name: Install Zoom (Ubuntu)
-  hosts: distro_Ubuntu
+  hosts:
+    - distro_Ubuntu
+    - distro_Pop!_OS
   become: true
   tags:
     - meeting

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -227,6 +227,7 @@
     - ansible.builtin.dnf:
         name:
           - snapd
+        state: latest
       when: ansible_facts["distribution"] == "Fedora"
 
     - name: Symlink
@@ -235,6 +236,13 @@
         dest: /snap
         state: link
       when: ansible_facts["distribution"] == "Fedora"
+
+    - name: Ensure snapd is installed (Ubuntu)
+      ansible.builtin.apt:
+        name:
+          - snapd
+        state: latest
+      when: ansible_facts["distribution"] == "Ubuntu"
 
     - name: Install packages
       community.general.snap:

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -13,6 +13,7 @@
     - name: Install general packages
       ansible.builtin.dnf:
         name:
+          - bash-completion
           - chromium
           - clang
           - dnf-plugins-core
@@ -54,6 +55,7 @@
         name:
           - apparmor-utils
           - apt-transport-https
+          - bash-completion
           - ca-certificates
           - curl
           - fish

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -126,12 +126,19 @@
         state: absent
 
 - name: Setup Flatpak and install packages
-  hosts: distro_Fedora
+  hosts: localhost
   tags:
     - flatpak
     - package-managers
     - packages
   tasks:
+    - name: Install Flatpak
+      ansible.builtin.apt:
+        name:
+          - flatpak
+        state: latest
+      when: ansible_facts["distribution"] == "Ubuntu"
+
     - name: Add Flathub repository
       community.general.flatpak_remote:
         name: flathub

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -175,6 +175,7 @@
     - packages
   tasks:
     - name: Install Flatpak
+      become: true
       ansible.builtin.apt:
         name:
           - flatpak

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -273,13 +273,14 @@
         path: /tmp/spacevim-install.sh
         state: absent
 
-- name: Install Zoom
+- name: Install Zoom (Fedora)
   hosts: distro_Fedora
   become: true
   tags:
     - meeting
     - packages
     - video
+    - zoom
   tasks:
     - name: Add GPG key
       ansible.builtin.rpm_key:
@@ -300,4 +301,34 @@
     - name: Clean up
       ansible.builtin.file:
         path: /tmp/zoom.rpm
+        state: absent
+
+- name: Install Zoom (Ubuntu)
+  hosts: distro_Ubuntu
+  become: true
+  tags:
+    - meeting
+    - packages
+    - video
+    - zoom
+  tasks:
+    - name: Add GPG key
+      ansible.builtin.apt_key:
+        keyserver: https://zoom.us/linux/download/pubkey
+        id: 396060CADD8A75220BFCB369B903BF1861A7C71D
+        state: present
+
+    - name: Download package
+      ansible.builtin.get_url:
+        url: https://zoom.us/client/latest/zoom_amd64.deb
+        dest: /tmp/zoom.deb
+
+    - name: Install
+      ansible.builtin.apt:
+        deb: /tmp/zoom.deb
+        state: present
+
+    - name: Clean up
+      ansible.builtin.file:
+        path: /tmp/zoom.deb
         state: absent

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -1,8 +1,9 @@
 ---
-- name: Install general packages (Fedora)
+- name: Install system packages (Fedora)
   hosts: distro_Fedora
   become: true
   tags:
+    - system-packages
     - packages
   tasks:
     - name: Update all
@@ -10,7 +11,7 @@
         name: "*"
         state: latest
 
-    - name: Install general packages
+    - name: Install system packages
       ansible.builtin.dnf:
         name:
           - bash-completion
@@ -31,10 +32,11 @@
       ansible.builtin.dnf:
         autoremove: yes
 
-- name: Install general packages (Ubuntu)
+- name: Install system packages (Ubuntu)
   hosts: distro_Ubuntu
   become: true
   tags:
+    - system-packages
     - packages
   tasks:
     - name: Update all
@@ -50,7 +52,7 @@
         state: present
         validate_certs: yes
 
-    - name: Install general packages
+    - name: Install system packages
       ansible.builtin.apt:
         name:
           - apparmor-utils

--- a/ansible/user.yml
+++ b/ansible/user.yml
@@ -19,7 +19,7 @@
     - name: Change shell
       become: true
       ansible.builtin.user:
-        name: "{{ ansible_env.USERNAME }}"
+        name: "{{ ansible_env.USER }}"
         shell: "{{ shell_path.stdout }}"
 
 - name: Link config files
@@ -61,7 +61,7 @@
     - user
   tasks:
     - ansible.builtin.user:
-        name: "{{ ansible_env.USERNAME }}"
+        name: "{{ ansible_env.USER }}"
         generate_ssh_key: yes
         ssh_key_type: "{{ ssh_key_type }}"
         ssh_key_file: "{{ ssh_key_file }}"


### PR DESCRIPTION
Tested on Pop!_OS 20.10.

- Changed use of `USERNAME` environment variable to `USER` as it is more common (standard?)
- Improved plays and tasks names, also to indicate the target distro
- Added plays to install Docker and Docker Compose
- Added `make` task for vimproc in SpaceVim play
- Ensuring `snapd` is installed (*Ubuntu* comes with it, but some others based on it don't)
- Install Flatpak on Ubuntu (not needed on Pop)
- Added play to install general system packages on Ubuntu (includes Pop)
- Added play for extra packages on Pop (Atom and Chromium)